### PR TITLE
Fix ABC103-D

### DIFF
--- a/ABC103-D-IslandsWar.cs
+++ b/ABC103-D-IslandsWar.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace AtCoder.ABC103.D
+{
+    class Program
+    {
+        static void Main()
+        {
+            var sc = new Scanner();
+            var n = sc.Nextint();
+            var m = sc.Nextint();
+            var demands = Enumerable.Range(0, m).Select(i => new { A = sc.Nextint(), B = sc.Nextint() }).ToArray();
+
+            var bridgeCnt = new int[n + 1];
+            foreach (var item in demands)
+            {
+                bridgeCnt[item.A]++;
+                bridgeCnt[item.B]--;
+            }
+
+            for (int i = 1; i < n + 1; i++)
+            {
+                bridgeCnt[i] += bridgeCnt[i - 1];
+            }
+
+            var deleteOrder = bridgeCnt.Select((val, idx) => new { Value = val, Index = idx }).OrderByDescending(elem => elem.Value).Select(elem => elem.Index);
+            var doneDemands = new bool[m];
+            var result = 0;
+            foreach (var item in deleteOrder)
+            {
+                var isDelete = false;
+                for (int i = 0; i < m; i++)
+                {
+                    if (doneDemands[i]) continue;
+                    if (demands[i].A <= item && item < demands[i].B)
+                    {
+                        isDelete = true;
+                        doneDemands[i] = true;
+                    }
+                }
+                if (isDelete) result++;
+                if (!doneDemands.Contains(false)) break;
+            }
+            Console.WriteLine(result);
+        }
+    }
+    class Scanner
+    {
+        string[] s;
+        long i;
+
+        char[] cs = new char[] { ' ' };
+
+        public Scanner()
+        {
+            s = new string[0];
+            i = 0;
+        }
+
+        public string Next()
+        {
+            if (i < s.Length) return s[i++];
+            string st = Console.ReadLine();
+            while (st == "") st = Console.ReadLine();
+            s = st.Split(cs, StringSplitOptions.RemoveEmptyEntries);
+            if (s.Length == 0) return Next();
+            i = 0;
+            return s[i++];
+        }
+
+        public int Nextint()
+        {
+            return int.Parse(Next());
+        }
+        public int[] Arrayint(int N, int add = 0)
+        {
+            int[] Array = new int[N];
+            for (int i = 0; i < N; i++)
+            {
+                Array[i] = Nextint() + add;
+            }
+            return Array;
+        }
+
+        public long NextLong()
+        {
+            return long.Parse(Next());
+        }
+
+        public long[] ArrayLong(int N, long add = 0)
+        {
+            long[] Array = new long[N];
+            for (long i = 0; i < N; i++)
+            {
+                Array[i] = NextLong() + add;
+            }
+            return Array;
+        }
+
+        public double NextDouble()
+        {
+            return double.Parse(Next());
+        }
+
+        public double[] ArrayDouble(long N, double add = 0)
+        {
+            double[] Array = new double[N];
+            for (long i = 0; i < N; i++)
+            {
+                Array[i] = NextDouble() + add;
+            }
+            return Array;
+        }
+
+        public decimal NextDecimal()
+        {
+            return decimal.Parse(Next());
+        }
+
+        public decimal[] ArrayDecimal(long N, decimal add = 0)
+        {
+            decimal[] Array = new decimal[N];
+            for (long i = 0; i < N; i++)
+            {
+                Array[i] = NextDecimal();
+            }
+            return Array;
+        }
+    }
+}

--- a/ABC103-D-IslandsWar.cs
+++ b/ABC103-D-IslandsWar.cs
@@ -18,37 +18,23 @@ namespace AtCoder.ABC103.D
             var m = sc.Nextint();
             var demands = Enumerable.Range(0, m).Select(i => new { A = sc.Nextint(), B = sc.Nextint() }).ToArray();
 
-            var bridgeCnt = new int[n + 1];
+            var maxRight = Enumerable.Repeat(n + 1, n).ToArray();
             foreach (var item in demands)
             {
-                bridgeCnt[item.A]++;
-                bridgeCnt[item.B]--;
+                maxRight[item.A] = Math.Min(maxRight[item.A], item.B);
             }
-
-            for (int i = 1; i < n + 1; i++)
+            var cnt = 0;
+            var r = n + 1;
+            for (int l = 1; l < n; l++)
             {
-                bridgeCnt[i] += bridgeCnt[i - 1];
-            }
-
-            var deleteOrder = bridgeCnt.Select((val, idx) => new { Value = val, Index = idx }).OrderByDescending(elem => elem.Value).Select(elem => elem.Index);
-            var doneDemands = new bool[m];
-            var result = 0;
-            foreach (var item in deleteOrder)
-            {
-                var isDelete = false;
-                for (int i = 0; i < m; i++)
+                r = Math.Min(maxRight[l], r);
+                if (r <= l + 1)
                 {
-                    if (doneDemands[i]) continue;
-                    if (demands[i].A <= item && item < demands[i].B)
-                    {
-                        isDelete = true;
-                        doneDemands[i] = true;
-                    }
+                    cnt++;
+                    r = n + 1;
                 }
-                if (isDelete) result++;
-                if (!doneDemands.Contains(false)) break;
             }
-            Console.WriteLine(result);
+            Console.WriteLine(cnt);
         }
     }
     class Scanner


### PR DESCRIPTION
最初のは争いが範囲に入った回数をいもす法で数えて、回数の多いところから見て
クエリを全部見てその橋を切って新規に満たせる要望があれば切るという方法。
後半、 `O(nm)` なので、 `10^10` まで行ってしまい間に合わない。

修正後のコードは人のコードを思いっきり参考にした。
まず各島に対して要望の一番近いものを持たせておく。
1番の島から見て切れる一番右の島の番号を `r` に入れておく。
まだ一緒に切れそうなら次の島を見ていく、これ以上一緒に切れそうに無くなったらカウントする。
なお `maxRight` は島の番号をインデックスに使うので `0` は不要、島の番号に `n` はあるが、 `1 <= ai < bi <= N` の条件からインデックスに使われるのは必ず `ai` で `n` にはならないので要素数は `n` で作ってる。ソートもしていないので、結果 `O(n)` で解ける。

うーん理屈が分かっても説明が難しい。。。
比較的コードがシンプルなので、コード見た方が分かりやすそう。