### PR TITLE
Fix abc098-D

### DIFF
--- a/ABC/ABC098/ABC098-D-XorSum2.cs
+++ b/ABC/ABC098/ABC098-D-XorSum2.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+// Wrong Answer
+namespace AtCoder.ABC098.D
+{
+    class Program
+    {
+        static void Main ()
+        {
+            var sc = new Scanner ();
+            var n = sc.Nextint ();
+            var A = sc.Arrayint (n);
+            var l = 0;
+            var r = 0;
+            var xor = A[0];
+            var sum = A[0];
+            var count = 0;
+            while (l < A.Length)
+            {
+                while (xor == sum && r < A.Length)
+                {
+                    if (++r >= A.Length) break;
+                    xor ^= A[r];
+                    sum += A[r];
+                }
+                count += r - l;
+                xor ^= A[l];
+                sum -= A[l];
+                l++;
+            }
+            Console.WriteLine (count);
+        }
+    }
+    class Scanner
+    {
+        string[] s;
+        long i;
+
+        char[] cs = new char[] { ' ' };
+
+        public Scanner ()
+        {
+            s = new string[0];
+            i = 0;
+        }
+
+        public string Next ()
+        {
+            if (i < s.Length) return s[i++];
+            string st = Console.ReadLine ();
+            while (st == "") st = Console.ReadLine ();
+            s = st.Split (cs, StringSplitOptions.RemoveEmptyEntries);
+            if (s.Length == 0) return Next ();
+            i = 0;
+            return s[i++];
+        }
+
+        public int Nextint ()
+        {
+            return int.Parse (Next ());
+        }
+        public int[] Arrayint (int N, int add = 0)
+        {
+            int[] Array = new int[N];
+            for (int i = 0; i < N; i++)
+            {
+                Array[i] = Nextint () + add;
+            }
+            return Array;
+        }
+
+        public long NextLong ()
+        {
+            return long.Parse (Next ());
+        }
+
+        public long[] ArrayLong (int N, long add = 0)
+        {
+            long[] Array = new long[N];
+            for (long i = 0; i < N; i++)
+            {
+                Array[i] = NextLong () + add;
+            }
+            return Array;
+        }
+
+        public double NextDouble ()
+        {
+            return double.Parse (Next ());
+        }
+
+        public double[] ArrayDouble (long N, double add = 0)
+        {
+            double[] Array = new double[N];
+            for (long i = 0; i < N; i++)
+            {
+                Array[i] = NextDouble () + add;
+            }
+            return Array;
+        }
+
+        public decimal NextDecimal ()
+        {
+            return decimal.Parse (Next ());
+        }
+
+        public decimal[] ArrayDecimal (long N, decimal add = 0)
+        {
+            decimal[] Array = new decimal[N];
+            for (long i = 0; i < N; i++)
+            {
+                Array[i] = NextDecimal ();
+            }
+            return Array;
+        }
+    }
+}

--- a/ABC/ABC098/ABC098-D-XorSum2.cs
+++ b/ABC/ABC098/ABC098-D-XorSum2.cs
@@ -10,11 +10,11 @@ namespace AtCoder.ABC098.D
 {
     class Program
     {
-        static void Main ()
+        static void Main()
         {
-            var sc = new Scanner ();
-            var n = sc.Nextint ();
-            var A = sc.Arrayint (n);
+            var sc = new Scanner();
+            var n = sc.Nextint();
+            var A = sc.Arrayint(n);
             var l = 0;
             var r = 0;
             var xor = A[0];
@@ -33,7 +33,7 @@ namespace AtCoder.ABC098.D
                 sum -= A[l];
                 l++;
             }
-            Console.WriteLine (count);
+            Console.WriteLine(count);
         }
     }
     class Scanner
@@ -43,78 +43,78 @@ namespace AtCoder.ABC098.D
 
         char[] cs = new char[] { ' ' };
 
-        public Scanner ()
+        public Scanner()
         {
             s = new string[0];
             i = 0;
         }
 
-        public string Next ()
+        public string Next()
         {
             if (i < s.Length) return s[i++];
-            string st = Console.ReadLine ();
-            while (st == "") st = Console.ReadLine ();
-            s = st.Split (cs, StringSplitOptions.RemoveEmptyEntries);
-            if (s.Length == 0) return Next ();
+            string st = Console.ReadLine();
+            while (st == "") st = Console.ReadLine();
+            s = st.Split(cs, StringSplitOptions.RemoveEmptyEntries);
+            if (s.Length == 0) return Next();
             i = 0;
             return s[i++];
         }
 
-        public int Nextint ()
+        public int Nextint()
         {
-            return int.Parse (Next ());
+            return int.Parse(Next());
         }
-        public int[] Arrayint (int N, int add = 0)
+        public int[] Arrayint(int N, int add = 0)
         {
             int[] Array = new int[N];
             for (int i = 0; i < N; i++)
             {
-                Array[i] = Nextint () + add;
+                Array[i] = Nextint() + add;
             }
             return Array;
         }
 
-        public long NextLong ()
+        public long NextLong()
         {
-            return long.Parse (Next ());
+            return long.Parse(Next());
         }
 
-        public long[] ArrayLong (int N, long add = 0)
+        public long[] ArrayLong(int N, long add = 0)
         {
             long[] Array = new long[N];
             for (long i = 0; i < N; i++)
             {
-                Array[i] = NextLong () + add;
+                Array[i] = NextLong() + add;
             }
             return Array;
         }
 
-        public double NextDouble ()
+        public double NextDouble()
         {
-            return double.Parse (Next ());
+            return double.Parse(Next());
         }
 
-        public double[] ArrayDouble (long N, double add = 0)
+        public double[] ArrayDouble(long N, double add = 0)
         {
             double[] Array = new double[N];
             for (long i = 0; i < N; i++)
             {
-                Array[i] = NextDouble () + add;
+                Array[i] = NextDouble() + add;
             }
             return Array;
         }
 
-        public decimal NextDecimal ()
+        public decimal NextDecimal()
         {
-            return decimal.Parse (Next ());
+            return decimal.Parse(Next());
         }
 
-        public decimal[] ArrayDecimal (long N, decimal add = 0)
+        public decimal[] ArrayDecimal(long N, decimal add = 0)
         {
             decimal[] Array = new decimal[N];
             for (long i = 0; i < N; i++)
             {
-                Array[i] = NextDecimal ();
+                Array[i] = NextDecimal();
             }
             return Array;
         }

--- a/ABC/ABC098/ABC098-D-XorSum2.cs
+++ b/ABC/ABC098/ABC098-D-XorSum2.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-// Wrong Answer
+
 namespace AtCoder.ABC098.D
 {
     class Program
@@ -17,9 +17,9 @@ namespace AtCoder.ABC098.D
             var A = sc.Arrayint(n);
             var l = 0;
             var r = 0;
-            var xor = A[0];
-            var sum = A[0];
-            var count = 0;
+            var xor = (long) A[0];
+            var sum = (long) A[0];
+            var count = 0L;
             while (l < A.Length)
             {
                 while (xor == sum && r < A.Length)


### PR DESCRIPTION
まさかの int 最大値超えによる WA、凡ミス…
明示的に long を指定することで AC。
内側のループは一度進めば外側のループが回っても戻ることは無いので O(n^2) では無いのだが、
while がネストしていて一見 O(n^2) に見えてしまうことはマイナス。
アイデアとしては他に

```
while l < A.Length:
    r++
    if xor == sum:
        count++
    elif:
        while xor != sum:
            xor ^= A[l]
            sum -= A[l]
            l++
        end loop
    end if
end loop
```

というように r を増やす毎にカウントして内側のループで l(L) を一気に進める方法もあるよう。
でも、内側のループで r を進めてカウントする法が直感的に分かりやすい気がするのでこちらを採用。